### PR TITLE
OTC-757: Clearing pagination state if entered the PayersPage

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,4 +3,6 @@ export const RIGHT_PAYERS_ADD = 121802;
 export const RIGHT_PAYERS_DELETE = 121804;
 export const RIGHT_PAYERS_EDIT = 121803;
 
+export const MODULE_NAME = "payer";
+
 export const PAYER_TYPES = ["C", "D", "G", "L", "O", "P"];

--- a/src/pages/PayersPage.js
+++ b/src/pages/PayersPage.js
@@ -9,7 +9,7 @@ import {
 } from "@openimis/fe-core";
 import { makeStyles } from "@material-ui/styles";
 import { useSelector, useDispatch } from "react-redux";
-import { RIGHT_PAYERS_ADD, RIGHT_PAYERS_DELETE } from "../constants";
+import { RIGHT_PAYERS_ADD, RIGHT_PAYERS_DELETE, MODULE_NAME } from "../constants";
 import { usePayerDeleteMutation } from "../hooks";
 import { Fab } from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
@@ -42,8 +42,7 @@ const PayersPage = (props) => {
   const canDelete = (payer) => rights.includes(RIGHT_PAYERS_DELETE) && !payer.validityTo;
 
   useEffect(() => {
-    const moduleName = "payer";
-    if (module !== moduleName) dispatch(clearCurrentPaginationPage());
+    if (module !== MODULE_NAME) dispatch(clearCurrentPaginationPage());
   }, [module]);
 
   return (

--- a/src/pages/PayersPage.js
+++ b/src/pages/PayersPage.js
@@ -1,7 +1,14 @@
-import React from "react";
-import { useTranslations, useModulesManager, historyPush, withTooltip, withHistory } from "@openimis/fe-core";
+import React, { useEffect } from "react";
+import {
+  useTranslations,
+  useModulesManager,
+  historyPush,
+  withTooltip,
+  withHistory,
+  clearCurrentPaginationPage,
+} from "@openimis/fe-core";
 import { makeStyles } from "@material-ui/styles";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { RIGHT_PAYERS_ADD, RIGHT_PAYERS_DELETE } from "../constants";
 import { usePayerDeleteMutation } from "../hooks";
 import { Fab } from "@material-ui/core";
@@ -15,9 +22,11 @@ const useStyles = makeStyles((theme) => ({
 
 const PayersPage = (props) => {
   const { history } = props;
+  const dispatch = useDispatch();
   const modulesManager = useModulesManager();
   const { formatMessage, formatMessageWithValues } = useTranslations("payer", modulesManager);
   const rights = useSelector((state) => state.core?.user?.i_user?.rights ?? []);
+  const module = useSelector((state) => state.core?.savedPagination?.module);
   const classes = useStyles();
   const deleteMutation = usePayerDeleteMutation();
   const onDoubleClick = (payer, newTab) =>
@@ -31,6 +40,11 @@ const PayersPage = (props) => {
   };
 
   const canDelete = (payer) => rights.includes(RIGHT_PAYERS_DELETE) && !payer.validityTo;
+
+  useEffect(() => {
+    const moduleName = "payer";
+    if (module !== moduleName) dispatch(clearCurrentPaginationPage());
+  }, [module]);
 
   return (
     <div className={classes.page}>


### PR DESCRIPTION
[OTC-757](https://openimis.atlassian.net/browse/OTC-757)

Changes:

- Clearing pagination state if entered the PayersPage.
- Implementation of the logic responsible for going back from edit form and keeping the same page which was before.

[OTC-757]: https://openimis.atlassian.net/browse/OTC-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ