### PR TITLE
CM-256: Add sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=openimis_openimis-fe-payer_js
+sonar.organization=openimis-1
+sonar.projectName=openimis-fe-payer_js
+
+sonar.sources=src
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Ticket: [CM-256](https://openimis.atlassian.net/browse/CM-256) This PR adds sonar-project.properties to configure SonarQube analysis.

[CM-256]: https://openimis.atlassian.net/browse/CM-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ