### PR TITLE
OP-1614: change payer type

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -64,7 +64,7 @@ export const usePayersQuery = ({ filters }, config) => {
     `
   query usePayersQuery (
     $first: Int, $last: Int, $before: String, $after: String, $phone: String, $name: String,
-    $email: String, $location: Int, $showHistory: Boolean, $search: String, $type: String,
+    $email: String, $location: Int, $showHistory: Boolean, $search: String, $type: PayerType,
     ) {
     payers (
       first: $first, last: $last, before: $before, after: $after, phone_Icontains: $phone, showHistory: $showHistory, type: $type


### PR DESCRIPTION
[OP-1614](https://openimis.atlassian.net/browse/OP-1614)

Changes:
- Changed type in query to proper one.
![image](https://github.com/openimis/openimis-fe-payer_js/assets/109145288/76155e90-f2f4-429d-bbbb-9a412d9ee729)

GQL QUERY:
`
query usePayersQuery($first: Int, $last: Int, $before: String, $after: String, $phone: String, $name: String, $email: String, $location: Int, $showHistory: Boolean, $search: String, $type: String) {
  payers(
    first: $first
    last: $last
    before: $before
    after: $after
    phone_Icontains: $phone
    showHistory: $showHistory
    type: $type
    name_Icontains: $name
    location: $location
    email_Icontains: $email
    search: $search
  ) {
    edges {
      node {
        id
        uuid
        ...PayerFragment
      }
    }
    pageInfo {
      hasNextPage
      hasPreviousPage
      startCursor
      endCursor
    }
    totalCount
  }
}

fragment PayerFragment on PayerGQLType {
  id
  uuid
  name
  email
  phone
  type
  address
  location {
    id
    name
    uuid
    code
    parent {
      id
      name
      uuid
      code
    }
  }
  validityFrom
  validityTo
}
`

VARIABLES:
`
{
  "first": 10
}
`


[OP-1614]: https://openimis.atlassian.net/browse/OP-1614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ