### PR TITLE
feat(payer): wrap PayerForm in ErrorBoundary and fix save permissions

### DIFF
--- a/src/components/PayerForm.js
+++ b/src/components/PayerForm.js
@@ -4,7 +4,7 @@ import clsx from "clsx";
 import { makeStyles } from "@material-ui/styles";
 import ReplayIcon from "@material-ui/icons/Replay";
 
-import { Form, ProgressOrError } from "@openimis/fe-core";
+import { Form, ProgressOrError, ErrorBoundary } from "@openimis/fe-core";
 import FundingPanel from "./FundingPanel";
 import MainPanelForm from "./MainPanelForm";
 
@@ -17,29 +17,31 @@ const PayerForm = ({ readOnly, onBack, onSave, payer, canSave, onReset, onChange
   const classes = useStyles();
   return (
     <div className={clsx(classes.page, readOnly && classes.locked)}>
-      <ProgressOrError error={error} />
-      <Form
-        module="payer"
-        title={payer?.uuid ? "payer.PayerForm.title" : "payer.PayerForm.emptyTitle"}
-        titleParams={{ label: payer.name ?? "" }}
-        readOnly={readOnly}
-        canSave={canSave}
-        onEditedChanged={onChange}
-        edited={payer}
-        edited_id={payer.uuid}
-        HeadPanel={MainPanelForm}
-        Panels={[FundingPanel]}
-        save={onSave}
-        back={onBack}
-        openDirty={onSave}
-        actions={[
-          {
-            doIt: onReset,
-            icon: <ReplayIcon />,
-            onlyIfDirty: !readOnly,
-          },
-        ]}
-      />
+      <ErrorBoundary>
+        <ProgressOrError error={error} />
+        <Form
+          module="payer"
+          title={payer?.uuid ? "payer.PayerForm.title" : "payer.PayerForm.emptyTitle"}
+          titleParams={{ label: payer.name ?? "" }}
+          readOnly={readOnly}
+          canSave={canSave}
+          onEditedChanged={onChange}
+          edited={payer}
+          edited_id={payer.uuid}
+          HeadPanel={MainPanelForm}
+          Panels={[FundingPanel]}
+          save={onSave}
+          back={onBack}
+          openDirty={onSave}
+          actions={[
+            {
+              doIt: onReset,
+              icon: <ReplayIcon />,
+              onlyIfDirty: !readOnly,
+            },
+          ]}
+        />
+        </ErrorBoundary>
     </div>
   );
 };

--- a/src/pages/PayerDetailsPage.js
+++ b/src/pages/PayerDetailsPage.js
@@ -69,7 +69,7 @@ const PayerDetailsPage = (props) => {
           payer={values}
           canSave={() => validatePayerForm(values)}
           onBack={() => historyPush(modulesManager, history, "payer.payers")}
-          onSave={rights.includes(RIGHT_PAYERS_EDIT) ? onSave : undefined}
+          onSave={rights.some((x) => [RIGHT_PAYERS_ADD, RIGHT_PAYERS_EDIT].includes(x)) ? onSave : undefined}
           onReset={onReset}
         />
       )}


### PR DESCRIPTION
- Wrap PayerForm content in ErrorBoundary to gracefully handle rendering errors
- Fix onSave permission check to allow users with RIGHT_PAYERS_ADD to save, not only those with RIGHT_PAYERS_EDIT

#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

Tested on vite (had the same issue) and it worked

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.


## Checklist

- [ ] Unit tests added/modified
- [ ] I18n / translation handled
